### PR TITLE
Fix User Clone Metadata Handling and Data Export Test Regressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,22 @@
 
 - fix bulk api on import.
 
+### Popup
+
+- Fix User cloning when formula or other non-updateable fields are present by using User describe metadata to select fields for create and update requests. [issue 290](https://github.com/dufoli/Salesforce-Inspector-Advanced/issues/290)
+- Allow a cloned User's email address to differ from its username.
+- Fix opening recently viewed records from the Users and Shortcuts search tabs. [issue 297](https://github.com/dufoli/Salesforce-Inspector-Advanced/issues/297)
+
+### Data Export
+
+- Fix autocomplete inside `IN (SELECT ...)` subqueries. [issue 296](https://github.com/dufoli/Salesforce-Inspector-Advanced/issues/296)
+
+### Tests
+
+- Grant the test permission set explicit read access to the tested objects and permission-set-controlled fields, including the Account Shipping address compound field.
+- Derive browser-test expectations for optional State/Country picklist fields, Account Type values, and feature-specific objects from the org describe response.
+- Update query-history assertions for the stored API type and automatic object tags.
+
 
 ## Version 1.38
 

--- a/addon/data-export-test.js
+++ b/addon/data-export-test.js
@@ -76,9 +76,25 @@ export async function dataExportTest(test) {
   setQuery("select Id, shipp", "", " from Account");
   assertEquals("select Id, shipp from Account", queryInput.value);
   assertEquals("Account fields suggestions:", vm.autocompleteResults.title);
-  assertEquals(["ShippingCity", "ShippingCountry", "ShippingGeocodeAccuracy", "ShippingLatitude", "ShippingLongitude", "ShippingPostalCode", "ShippingState", "ShippingStreet"], getValues(vm.autocompleteResults.results));
+  const shippingSuggestionValues = getValues(vm.autocompleteResults.results);
+  const hasShippingCountryCode = shippingSuggestionValues.includes("ShippingCountryCode");
+  const hasShippingStateCode = shippingSuggestionValues.includes("ShippingStateCode");
+  const expectedShippingSuggestionValues = ["ShippingCity", "ShippingCountry"];
+  if (hasShippingCountryCode) {
+    expectedShippingSuggestionValues.push("ShippingCountryCode");
+  }
+  expectedShippingSuggestionValues.push("ShippingGeocodeAccuracy", "ShippingLatitude", "ShippingLongitude", "ShippingPostalCode", "ShippingState");
+  if (hasShippingStateCode) {
+    expectedShippingSuggestionValues.push("ShippingStateCode");
+  }
+  expectedShippingSuggestionValues.push("ShippingStreet");
+  assertEquals(expectedShippingSuggestionValues, shippingSuggestionValues);
+  const {sobjectDescribe: accountDescribe} = vm.describeInfo.describeSobject(vm.queryTooling, "Account");
+  const expectedShippingFieldOrder = accountDescribe.fields
+    .filter(field => field.type != "address" && (field.name.toLowerCase().includes("shipp") || field.label.toLowerCase().includes("shipp")))
+    .map(field => field.name);
   vm.editorAutocompleteHandler({ctrlSpace: true});
-  assertEquals("select Id, ShippingStreet, ShippingCity, ShippingState, ShippingPostalCode, ShippingCountry, ShippingLatitude, ShippingLongitude, ShippingGeocodeAccuracy from Account", queryInput.value);
+  assertEquals("select Id, " + expectedShippingFieldOrder.join(", ") + " from Account", queryInput.value);
 
   // Autocomplete relationship field in SELECT
   setQuery("select Id, OWNE", "", " from Account");
@@ -124,11 +140,18 @@ export async function dataExportTest(test) {
   assertEquals("select Id from Account where Sic ", queryInput.value);
 
   // Autocomplete picklist value
-  setQuery("select Id from Account where Type = cust", "", "");
+  const typeField = accountDescribe.fields.find(field => field.name == "Type");
+  assert(typeField, "Expected Account describe to include the Type field");
+  const typePicklistValue = typeField.picklistValues.find(picklistValue => picklistValue.active !== false);
+  assert(typePicklistValue, "Expected Account.Type to have an active picklist value");
+  const typeSearchTerm = typePicklistValue.value.match(/[a-zA-Z0-9]+/);
+  assert(typeSearchTerm, "Expected Account.Type picklist value to contain a searchable character");
+  setQuery("select Id from Account where Type = " + typeSearchTerm[0], "", "");
   assertEquals("Account.Type values:", vm.autocompleteResults.title);
-  assertEquals(["'Customer - Channel'", "'Customer - Direct'"], getValues(vm.autocompleteResults.results));
-  vm.autocompleteClick(vm.autocompleteResults.results[1], 1);
-  assertEquals("select Id from Account where Type = 'Customer - Direct' ", queryInput.value);
+  const typePicklistResult = vm.autocompleteResults.results.find(result => result.value == "'" + typePicklistValue.value + "'");
+  assert(typePicklistResult, "Expected Account.Type autocomplete to include a described picklist value");
+  vm.autocompleteClick(typePicklistResult, vm.autocompleteResults.results.indexOf(typePicklistResult));
+  assertEquals("select Id from Account where Type = '" + typePicklistValue.value + "' ", queryInput.value);
 
   // Autocomplete boolean value
   setQuery("select Id from Account where IsDeleted != ", "", "");
@@ -147,7 +170,7 @@ export async function dataExportTest(test) {
   // Autocomplete object
   setQuery("select Id from OpportunityLi", "", "");
   assertEquals("Objects suggestions:", vm.autocompleteResults.title);
-  assertEquals(["OpportunityLineItem"], getValues(vm.autocompleteResults.results));
+  assert(getValues(vm.autocompleteResults.results).includes("OpportunityLineItem"), "Expected OpportunityLineItem autocomplete suggestion");
 
   // Autocomplete unknown object
   setQuery("select Id from UnknownObj", "", "");
@@ -544,12 +567,12 @@ export async function dataExportTest(test) {
 
   // Query history
   assertEquals([
-    {query: "select Name from ApexClass", useToolingApi: true},
-    {query: "select Id from Inspector_Test__c", useToolingApi: false},
-    {query: "select count() from Inspector_Test__c", useToolingApi: false},
-    {query: "select Id from Inspector_Test__c where name = 'no such name'", useToolingApi: false},
-    {query: "select Name, Lookup__r.Name from Inspector_Test__c order by Name", useToolingApi: false},
-    {query: "select Name, Checkbox__c, Number__c from Inspector_Test__c order by Name", useToolingApi: false}
+    {query: "select Name from ApexClass", useToolingApi: true, apiType: "query", tags: ["ApexClass"]},
+    {query: "select Id from Inspector_Test__c", useToolingApi: false, apiType: "query", tags: ["Inspector_Test__c"]},
+    {query: "select count() from Inspector_Test__c", useToolingApi: false, apiType: "query", tags: ["Inspector_Test__c"]},
+    {query: "select Id from Inspector_Test__c where name = 'no such name'", useToolingApi: false, apiType: "query", tags: ["Inspector_Test__c"]},
+    {query: "select Name, Lookup__r.Name from Inspector_Test__c order by Name", useToolingApi: false, apiType: "query", tags: ["Inspector_Test__c"]},
+    {query: "select Name, Checkbox__c, Number__c from Inspector_Test__c order by Name", useToolingApi: false, apiType: "query", tags: ["Inspector_Test__c"]}
   ], vm.queryHistory.list);
   vm.selectedHistoryEntry = vm.queryHistory.list[2];
   vm.selectHistoryEntry();
@@ -677,9 +700,9 @@ export async function dataExportTest(test) {
   setQuery("find {test} returning Account(Id, shipp", "", ")");
   assertEquals("find {test} returning Account(Id, shipp)", queryInput.value);
   assertEquals("Account fields suggestions:", vm.autocompleteResults.title);
-  assertEquals(["ShippingCity", "ShippingCountry", "ShippingGeocodeAccuracy", "ShippingLatitude", "ShippingLongitude", "ShippingPostalCode", "ShippingState", "ShippingStreet"], getValues(vm.autocompleteResults.results));
+  assertEquals(expectedShippingSuggestionValues, getValues(vm.autocompleteResults.results));
   vm.editorAutocompleteHandler({ctrlSpace: true});
-  assertEquals("find {test} returning Account(Id, ShippingStreet, ShippingCity, ShippingState, ShippingPostalCode, ShippingCountry, ShippingLatitude, ShippingLongitude, ShippingGeocodeAccuracy)", queryInput.value);
+  assertEquals("find {test} returning Account(Id, " + expectedShippingFieldOrder.join(", ") + ")", queryInput.value);
 
   // Autocomplete relationship field in SELECT
   setQuery("find {test} returning Account(Id, OWNE", "", ")");

--- a/addon/data-export.js
+++ b/addon/data-export.js
@@ -844,6 +844,9 @@ class Model {
 
     // Start after the opening parenthesis
     let pos = inMatch.index + inMatch[0].length;
+    if (inMatch[1].toLowerCase() == "in" && text.substring(pos).match(/^select\b/i)) {
+      return null;
+    }
     let parenDepth = 1;
     let inString = false;
 

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1379,7 +1379,7 @@ class AllDataBoxUsers extends React.PureComponent {
 
     return (
       h("div", {ref: "usersBox", className: "users-box"},
-        h(AllDataSearch, {ref: "allDataSearch", getMatches: this.getMatches, onDataSelect: this.onDataSelect, inputSearchDelay: 400, placeholderText: "Username, email, alias or name of user", resultRender: this.resultRender}),
+        h(AllDataSearch, {ref: "allDataSearch", sfHost, getMatches: this.getMatches, onDataSelect: this.onDataSelect, inputSearchDelay: 400, placeholderText: "Username, email, alias or name of user", resultRender: this.resultRender}),
         h("div", {className: "all-data-box-inner" + (!selectedUser ? " empty" : "")},
           selectedUser
             ? h(UserDetails, {user: selectedUser, sfHost, contextOrgId, currentUserId: contextUserId, linkTarget, contextPath})
@@ -1890,7 +1890,7 @@ class AllDataBoxShortcut extends React.PureComponent {
 
     return (
       h("div", {ref: "shortcutsBox", className: "users-box"},
-        h(AllDataSearch, {ref: "allDataSearch", getMatches: this.getMatches, onDataSelect: this.onDataSelect, inputSearchDelay: 200, placeholderText: "Quick find links, shortcuts", resultRender: this.resultRender}),
+        h(AllDataSearch, {ref: "allDataSearch", sfHost, getMatches: this.getMatches, onDataSelect: this.onDataSelect, inputSearchDelay: 200, placeholderText: "Quick find links, shortcuts", resultRender: this.resultRender}),
         h("div", {className: "all-data-box-inner" + (!selectedUser ? " empty" : "")},
           selectedUser
             ? h(UserDetails, {user: selectedUser, sfHost, contextOrgId, currentUserId: contextUserId, linkTarget, contextPath})
@@ -2196,6 +2196,11 @@ class UserDetails extends React.PureComponent {
       return;
     }
 
+    const email = prompt("Enter email for the new user:", username);
+    if (!email) {
+      return;
+    }
+
     const firstname = prompt("Enter first name:", "");
     if (!firstname) {
       return;
@@ -2229,7 +2234,10 @@ class UserDetails extends React.PureComponent {
         groups: groupQuery
       });
 
-      const results = await sfConn.rest("/services/data/v" + apiVersion + "/composite", {method: "POST", body: compositeQuery});
+      const [results, userDescribe] = await Promise.all([
+        sfConn.rest("/services/data/v" + apiVersion + "/composite", {method: "POST", body: compositeQuery}),
+        sfConn.rest("/services/data/v" + apiVersion + "/sobjects/User/describe")
+      ]);
 
       // Check for errors in composite response
       const userDataResponse = results.compositeResponse.find(r => r.referenceId === "userData");
@@ -2242,10 +2250,13 @@ class UserDetails extends React.PureComponent {
         throw new Error("Source user not found");
       }
 
-      // Prepare new user object with copied properties
+      const userFields = new Map(userDescribe.fields.map(field => [field.name, field]));
+
+      // Prepare new user object with copied properties.
+      // Fields that are only updateable must be set after the User record is created.
       const newUser = {
         Username: username,
-        Email: username, // Email same as username
+        Email: email,
         FirstName: firstname,
         LastName: lastname,
         Alias: (firstname.substring(0, 1) + lastname.substring(0, 7)).toUpperCase(),
@@ -2258,6 +2269,7 @@ class UserDetails extends React.PureComponent {
         FederationIdentifier: username,
         IsActive: true,
       };
+      const updatedUser = {};
       Object.keys(sourceUser)
         .filter(userField => userField !== "Id"
           && userField !== "Attributes"
@@ -2311,14 +2323,22 @@ class UserDetails extends React.PureComponent {
           && userField !== "LastReferencedDate"
           && sourceUser[userField] != null)
         .forEach(userField => {
-          newUser[userField] = sourceUser[userField];
+          const userFieldMetadata = userFields.get(userField);
+          if (userFieldMetadata?.createable) {
+            newUser[userField] = sourceUser[userField];
+          } else if (userFieldMetadata?.updateable) {
+            updatedUser[userField] = sourceUser[userField];
+          }
         });
       // Create the new user
       const createUserResponse = await sfConn.rest("/services/data/v" + apiVersion + "/sobjects/User", {method: "POST", body: newUser});
       const newUserId = createUserResponse.id;
-
       if (!newUserId) {
         throw new Error("Failed to create new user");
+      }
+
+      if (Object.keys(updatedUser).length > 0) {
+        await sfConn.rest("/services/data/v" + apiVersion + "/sobjects/User/" + newUserId, {method: "PATCH", body: updatedUser});
       }
 
       // Prepare assignments for composite request

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -11,6 +11,10 @@ Then you can check result on log and go to log analyzer to analyze it.
 
 ![image](screenshots/viewLog.png)
 
+## Clone a User
+
+From the extension's Users tab, select an active user and click **Clone**. Enter a unique username, then enter the user's email address. The email prompt defaults to the username but can be changed independently. Complete the first-name and last-name prompts to create the user with the source user's writable fields and assignments.
+
 ## log analyzer
 
 The analyzer have 2 tabs. 

--- a/test/main/default/permissionsets/SfInspector.permissionset-meta.xml
+++ b/test/main/default/permissionsets/SfInspector.permissionset-meta.xml
@@ -2,6 +2,31 @@
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>Grant access to objects and fields from Salesforce inspector tests</description>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.Ownership</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.ShippingAddress</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.Sic</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.SicDesc</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.Type</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Inspector_Test__c.Checkbox__c</field>
         <readable>true</readable>
@@ -16,8 +41,35 @@
         <field>Inspector_Test__c.Number__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Opportunity.AccountId</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Asset.AccountId</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Asset.Price</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Sf Inspector</label>
+    <objectPermissions>
+        <allowRead>true</allowRead>
+        <object>Account</object>
+    </objectPermissions>
+    <objectPermissions>
+        <allowRead>true</allowRead>
+        <object>Asset</object>
+    </objectPermissions>
+    <objectPermissions>
+        <allowRead>true</allowRead>
+        <object>Contact</object>
+    </objectPermissions>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>true</allowDelete>
@@ -26,5 +78,9 @@
         <modifyAllRecords>true</modifyAllRecords>
         <object>Inspector_Test__c</object>
         <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowRead>true</allowRead>
+        <object>Opportunity</object>
     </objectPermissions>
 </PermissionSet>


### PR DESCRIPTION
  ## Describe your changes

  - Fix User cloning by using User describe metadata to create only createable fields and apply updateable-only fields after
  - Allow a cloned user’s email address to differ from its username.
  - Fix Recently Viewed record links in the Users and Shortcuts tabs.
  - Fix Data Export autocomplete inside `IN (SELECT ...)` subqueries.
  - Make browser tests resilient to supported org configuration and permission differences.

  ## Issue ticket number and link

  Fixes #290
  Fixes #296
  Fixes #297

  ## Checklist before requesting a review

  - [x] I have read and understand the [Contributions section](https://github.com/dufoli/Salesforce-Inspector-Advanced#contributions)
  - [x] I have performed a self-review of my code
  - [x] I ran the [unit tests](https://github.com/dufoli/Salesforce-Inspector-Advanced#unit-tests) and my PR does not break
  - [x] I documented the changes I've made on the [CHANGES.md](https://github.com/dufoli/Salesforce-Inspector-Advanced/blob/ CHANGES.md) and followed actual conventions
  - [x] I added a new section on [how-to.md](https://github.com/dufoli/Salesforce-Inspector-Advanced/blob/master/docs/how-to
  (optional)